### PR TITLE
November 14th - Implementation of GetUsernames and UsernameExists

### DIFF
--- a/Tweeter.Tests/DAL/TweeterRepoTests.cs
+++ b/Tweeter.Tests/DAL/TweeterRepoTests.cs
@@ -83,7 +83,32 @@ namespace Tweeter.Tests.DAL
 
             // Assert
             Assert.AreEqual(2, usernames.Count);
+        }
 
+        [TestMethod]
+        public void RepoEnsureUsernameExists()
+        {
+            // Arrange
+            ConnectToDatastore();
+
+            // Act
+            bool exists = Repo.UsernameExists("sallym");
+
+            // Assert
+            Assert.IsTrue(exists);
+        }
+
+        [TestMethod]
+        public void RepoEnsureUsernameExistsOfTwit()
+        {
+            // Arrange
+            ConnectToDatastore();
+
+            // Act
+            Twit found_twit = Repo.UsernameExistsOfTwit("sallym");
+
+            // Assert
+            Assert.IsNotNull(found_twit);
         }
     }
 }

--- a/Tweeter.Tests/DAL/TweeterRepoTests.cs
+++ b/Tweeter.Tests/DAL/TweeterRepoTests.cs
@@ -13,17 +13,29 @@ namespace Tweeter.Tests.DAL
     public class TweeterRepoTests
     {
 
-        private Mock<DbSet<ApplicationUser>> mock_users { get; set; }
+        private Mock<DbSet<Twit>> mock_users { get; set; }
         private Mock<TweeterContext> mock_context { get; set; }
         private TweeterRepository Repo { get; set; }
-        private List<ApplicationUser> users { get; set; }
+        private List<Twit> users { get; set; }
 
         [TestInitialize]
         public void Initialize()
         {
             mock_context = new Mock<TweeterContext>();
-            mock_users = new Mock<DbSet<ApplicationUser>>();
+            mock_users = new Mock<DbSet<Twit>>();
             Repo = new TweeterRepository(mock_context.Object);
+            users = new List<Twit>
+            {
+                new Twit {
+                    TwitId = 1,
+                    BaseUser = new ApplicationUser() { UserName = "michealb"}
+                },
+                new Twit {
+                    TwitId = 2,
+                    BaseUser = new ApplicationUser() { UserName = "sallym"}
+                }
+
+            };
 
             /* 
              1. Install Identity into Tweeter.Tests (using statement needed)
@@ -33,14 +45,15 @@ namespace Tweeter.Tests.DAL
 
         public void ConnectToDatastore()
         {
-            users = new List<ApplicationUser>();
             var query_users = users.AsQueryable();
 
-            mock_users.As<IQueryable<ApplicationUser>>().Setup(m => m.Provider).Returns(query_users.Provider);
-            mock_users.As<IQueryable<ApplicationUser>>().Setup(m => m.Expression).Returns(query_users.Expression);
-            mock_users.As<IQueryable<ApplicationUser>>().Setup(m => m.ElementType).Returns(query_users.ElementType);
-            mock_users.As<IQueryable<ApplicationUser>>().Setup(m => m.GetEnumerator()).Returns(() => query_users.GetEnumerator());
+            mock_users.As<IQueryable<Twit>>().Setup(m => m.Provider).Returns(query_users.Provider);
+            mock_users.As<IQueryable<Twit>>().Setup(m => m.Expression).Returns(query_users.Expression);
+            mock_users.As<IQueryable<Twit>>().Setup(m => m.ElementType).Returns(query_users.ElementType);
+            mock_users.As<IQueryable<Twit>>().Setup(m => m.GetEnumerator()).Returns(() => query_users.GetEnumerator());
 
+            mock_context.Setup(c => c.TweeterUsers).Returns(mock_users.Object);
+            mock_users.Setup(u => u.Add(It.IsAny<Twit>())).Callback((Twit t) => users.Add(t));
             /*
              * Below mocks the 'Users' getter that returns a list of ApplicationUsers
              * mock_user_manager_context.Setup(c => c.Users).Returns(mock_users.Object);
@@ -62,6 +75,14 @@ namespace Tweeter.Tests.DAL
         [TestMethod]
         public void RepoEnsureICanGetUsernames()
         {
+            // Arrange
+            ConnectToDatastore();
+
+            // Act
+            List<string> usernames = Repo.GetUsernames();
+
+            // Assert
+            Assert.AreEqual(2, usernames.Count);
 
         }
     }

--- a/Tweeter.Tests/Tweeter.Tests.csproj
+++ b/Tweeter.Tests/Tweeter.Tests.csproj
@@ -45,6 +45,14 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.EntityFramework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.1\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>

--- a/Tweeter.Tests/packages.config
+++ b/Tweeter.Tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />

--- a/Tweeter/Controllers/TweeterController.cs
+++ b/Tweeter/Controllers/TweeterController.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace Tweeter.Controllers
+{
+    public class TweeterController : ApiController
+    {
+        // GET api/<controller>
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/<controller>/5
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/<controller>
+        public void Post([FromBody]string value)
+        {
+        }
+
+        // PUT api/<controller>/5
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/<controller>/5
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/Tweeter/Controllers/TwitUsernameController.cs
+++ b/Tweeter/Controllers/TwitUsernameController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Tweeter.DAL;
+
+namespace Tweeter.Controllers
+{
+    public class TwitUsernameController : ApiController
+    {
+
+        TweeterRepository repo = new TweeterRepository();
+
+        // GET api/<controller>
+        public IEnumerable<string> Get()
+        {
+            return repo.GetUsernames();
+        }
+
+        // GET api/<controller>/5
+        public Dictionary<string,bool> Get(string candidate)
+        {
+            /*
+             { "exists": true}
+            */
+
+            Dictionary<string, bool> answer = new Dictionary<string, bool>();
+            answer.Add("exists", repo.UsernameExists(candidate));
+
+            return answer;
+
+        }
+
+    }
+}

--- a/Tweeter/DAL/TweeterRepository.cs
+++ b/Tweeter/DAL/TweeterRepository.cs
@@ -15,6 +15,9 @@ namespace Tweeter.DAL
 
         public TweeterRepository() {}
 
-
+        public List<string> GetUsernames()
+        {
+            return Context.TweeterUsers.Select(u => u.BaseUser.UserName).ToList();
+        }
     }
 }

--- a/Tweeter/DAL/TweeterRepository.cs
+++ b/Tweeter/DAL/TweeterRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using Tweeter.Models;
 
 namespace Tweeter.DAL
 {
@@ -18,6 +19,32 @@ namespace Tweeter.DAL
         public List<string> GetUsernames()
         {
             return Context.TweeterUsers.Select(u => u.BaseUser.UserName).ToList();
+        }
+
+        public Twit UsernameExistsOfTwit(string v)
+        {
+            return Context.TweeterUsers.FirstOrDefault(u => u.BaseUser.UserName.ToLower() == v.ToLower());
+        }
+
+        public bool UsernameExists(string v)
+        {
+            // Works if mocked the UserManager
+            /*
+            if (Context.Users.Any(u => u.UserName.Contains(v)))
+            {
+                return true;
+            }
+            return false;
+            */
+            
+            Twit found_twit = Context.TweeterUsers.FirstOrDefault(u => u.BaseUser.UserName.ToLower() == v.ToLower());
+            if (found_twit != null)
+            {
+                return true;
+            }
+
+            return false;
+            
         }
     }
 }

--- a/Tweeter/Models/Twit.cs
+++ b/Tweeter/Models/Twit.cs
@@ -15,7 +15,7 @@ namespace Tweeter.Models
          * Then you'll need to mock the Twit table to return List<Twit>
          * This clearly means that you need to EITHER: 
          *     1. Re-scaffold the InitialCreate migration OR 
-         *     2. Create a new Migration that adds this field.S
+         *     2. Create a new Migration that adds this field.
          */
     }
 }

--- a/Tweeter/Tweeter.csproj
+++ b/Tweeter/Tweeter.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\ManageController.cs" />
+    <Compile Include="Controllers\TweeterController.cs" />
+    <Compile Include="Controllers\TwitUsernameController.cs" />
     <Compile Include="DAL\TweeterContext.cs" />
     <Compile Include="DAL\TweeterRepository.cs" />
     <Compile Include="Global.asax.cs">


### PR DESCRIPTION
This PR contains the following:

- `TwitUsernameController` that contains 2 implemented API endpoints.
- `TweeterController` (not used yet)
- `GetUsernames() Implementation and unit test`
- `UsernameExists(string)` implementation and unit test (contains 2 solutions)
- `UsernameExistsOfTwit(string)` alternate approach for implementation for `UsernameExists` returning a `Twit` type.