### PR TITLE
November 16th - Repository Methods for Tweets with WebAPI

### DIFF
--- a/Tweeter.Tests/DAL/TweeterRepoTests.cs
+++ b/Tweeter.Tests/DAL/TweeterRepoTests.cs
@@ -14,15 +14,19 @@ namespace Tweeter.Tests.DAL
     {
 
         private Mock<DbSet<Twit>> mock_users { get; set; }
+        private Mock<DbSet<Tweet>> mock_tweets { get; set; }
         private Mock<TweeterContext> mock_context { get; set; }
         private TweeterRepository Repo { get; set; }
         private List<Twit> users { get; set; }
+        private List<Tweet> tweets { get; set; }
+
 
         [TestInitialize]
         public void Initialize()
         {
             mock_context = new Mock<TweeterContext>();
             mock_users = new Mock<DbSet<Twit>>();
+            mock_tweets = new Mock<DbSet<Tweet>>();
             Repo = new TweeterRepository(mock_context.Object);
             users = new List<Twit>
             {
@@ -37,6 +41,8 @@ namespace Tweeter.Tests.DAL
 
             };
 
+            tweets = new List<Tweet>();
+
             /* 
              1. Install Identity into Tweeter.Tests (using statement needed)
              2. Create a mock context that uses 'UserManager' instead of 'TweeterContext'
@@ -46,6 +52,7 @@ namespace Tweeter.Tests.DAL
         public void ConnectToDatastore()
         {
             var query_users = users.AsQueryable();
+            var query_tweets = tweets.AsQueryable();
 
             mock_users.As<IQueryable<Twit>>().Setup(m => m.Provider).Returns(query_users.Provider);
             mock_users.As<IQueryable<Twit>>().Setup(m => m.Expression).Returns(query_users.Expression);
@@ -63,6 +70,17 @@ namespace Tweeter.Tests.DAL
             /* IF we just add a Username field to the Twit model
              * mock_context.Setup(c => c.TweeterUsers).Returns(mock_users.Object); Assuming mock_users is List<Twit>
              */
+
+            mock_tweets.As<IQueryable<Tweet>>().Setup(m => m.Provider).Returns(query_tweets.Provider);
+            mock_tweets.As<IQueryable<Tweet>>().Setup(m => m.Expression).Returns(query_tweets.Expression);
+            mock_tweets.As<IQueryable<Tweet>>().Setup(m => m.ElementType).Returns(query_tweets.ElementType);
+            mock_tweets.As<IQueryable<Tweet>>().Setup(m => m.GetEnumerator()).Returns(() => query_tweets.GetEnumerator());
+
+            mock_context.Setup(c => c.Tweets).Returns(mock_tweets.Object);
+            mock_tweets.Setup(u => u.Add(It.IsAny<Tweet>())).Callback((Tweet t) => tweets.Add(t));
+            mock_tweets.Setup(u => u.Remove(It.IsAny<Tweet>())).Callback((Tweet t) => tweets.Remove(t));
+
+
         }
 
         [TestMethod]
@@ -109,6 +127,70 @@ namespace Tweeter.Tests.DAL
 
             // Assert
             Assert.IsNotNull(found_twit);
+        }
+
+        [TestMethod]
+        public void RepoEnsureICanCreateTweet()
+        {
+            // Arrange
+            ConnectToDatastore();
+
+            // Act
+            Tweet a_tweet = new Tweet {
+                TweetId = 1,
+                Message = "my message",
+                Author = new Twit { TwitId = 1, BaseUser = new ApplicationUser { UserName = "jcockhren" } },
+                CreatedAt = DateTime.Now
+            };
+            Repo.AddTweet(a_tweet);
+
+            int expected_tweets = 1;
+            int actual_tweets = Repo.Context.Tweets.Count();
+
+            // Assert
+            Assert.AreEqual(expected_tweets, actual_tweets);
+        }
+
+        [TestMethod]
+        public void RepoEnsureICanCreateTweetWithMessage()
+        {
+            // Arrange
+            ConnectToDatastore();
+
+            // Act
+            Repo.AddTweet("sallym", "my tweet!!!!");
+
+            int expected_tweets = 1;
+            int actual_tweets = Repo.Context.Tweets.Count();
+
+            // Assert
+            Assert.AreEqual(expected_tweets, actual_tweets);
+        }
+
+        [TestMethod]
+        public void RepoEnsureICanRemoveTweet()
+        {
+            // Arrange
+            ConnectToDatastore();
+            Tweet a_tweet = new Tweet
+            {
+                TweetId = 3,
+                Message = "my message",
+                CreatedAt = DateTime.Now,
+                Author = new Twit { TwitId = 3, BaseUser = new ApplicationUser { UserName = "jcockhren" } }
+            };
+            Repo.AddTweet(a_tweet);
+
+            // Act
+
+            Tweet removed_tweet = Repo.RemoveTweet(3);
+
+            int expected_tweets = 0;
+            int actual_tweets = Repo.Context.Tweets.Count();
+
+            // Assert
+            Assert.AreEqual(expected_tweets, actual_tweets);
+            Assert.IsNotNull(removed_tweet);
         }
     }
 }

--- a/Tweeter.Tests/DAL/TweeterRepoTests.cs
+++ b/Tweeter.Tests/DAL/TweeterRepoTests.cs
@@ -179,18 +179,42 @@ namespace Tweeter.Tests.DAL
                 CreatedAt = DateTime.Now,
                 Author = new Twit { TwitId = 3, BaseUser = new ApplicationUser { UserName = "jcockhren" } }
             };
+            Tweet another_tweet = new Tweet
+            {
+                TweetId = 4,
+                Message = "my message",
+                CreatedAt = DateTime.Now,
+                Author = new Twit { TwitId = 4, BaseUser = new ApplicationUser { UserName = "sallym" } }
+            };
             Repo.AddTweet(a_tweet);
+            Repo.AddTweet(another_tweet);
 
             // Act
 
             Tweet removed_tweet = Repo.RemoveTweet(3);
 
-            int expected_tweets = 0;
+            int expected_tweets = 1;
             int actual_tweets = Repo.Context.Tweets.Count();
 
             // Assert
             Assert.AreEqual(expected_tweets, actual_tweets);
             Assert.IsNotNull(removed_tweet);
+        }
+
+        [TestMethod]
+        public void RepoEnsureICanGetTweets()
+        {
+            // Arrange
+            ConnectToDatastore();
+            Repo.AddTweet("sallym", "my tweet!!!!");
+            
+            // Act
+
+            int expected_tweets = 1;
+            int actual_tweets = Repo.GetTweets().Count();
+
+            // Assert
+            Assert.AreEqual(expected_tweets, actual_tweets);
         }
     }
 }

--- a/Tweeter/Controllers/TweetController.cs
+++ b/Tweeter/Controllers/TweetController.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Tweeter.DAL;
+using Tweeter.Models;
+
+namespace Tweeter.Controllers
+{
+    public class TweetController : ApiController
+    {
+        TweeterRepository Repo = new TweeterRepository();
+
+        // GET api/<controller>
+        public IEnumerable<Tweet> Get()
+        {
+            return Repo.GetTweets();
+        }
+
+        // GET api/<controller>/5
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/<controller>
+        public void Post([FromBody]Tweet new_tweet)
+        {
+            Repo.AddTweet(new_tweet);
+        }
+
+        // PUT api/<controller>/5
+        public void Put(int id, [FromBody]string value)
+        {
+        }
+
+        // DELETE api/<controller>/5
+        public void Delete(int id)
+        {
+            Repo.RemoveTweet(id);
+        }
+    }
+}

--- a/Tweeter/Controllers/TweetController.cs
+++ b/Tweeter/Controllers/TweetController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.AspNet.Identity;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -6,6 +7,7 @@ using System.Net.Http;
 using System.Web.Http;
 using Tweeter.DAL;
 using Tweeter.Models;
+using static Tweeter.Models.TweeterViewModels;
 
 namespace Tweeter.Controllers
 {
@@ -26,9 +28,24 @@ namespace Tweeter.Controllers
         }
 
         // POST api/<controller>
-        public void Post([FromBody]Tweet new_tweet)
+        public void Post([FromBody]TweetViewModel tweet)
         {
-            Repo.AddTweet(new_tweet);
+            
+            if (ModelState.IsValid && User.Identity.IsAuthenticated)
+            {
+                string user_id = User.Identity.GetUserId();
+                ApplicationUser found_app_user = Repo.Context.Users.FirstOrDefault(u => u.Id == user_id);
+                Twit found_user = Repo.Context.TweeterUsers.FirstOrDefault(twit => twit.BaseUser.UserName == found_app_user.UserName);
+                Tweet new_tweet = new Tweet
+                {
+                    Message = tweet.Message,
+                    ImageURL = tweet.ImageURL,
+                    Author = found_user,
+                    CreatedAt = DateTime.Now
+                };
+                Repo.AddTweet(new_tweet);
+            }
+            
         }
 
         // PUT api/<controller>/5

--- a/Tweeter/DAL/TweeterRepository.cs
+++ b/Tweeter/DAL/TweeterRepository.cs
@@ -46,5 +46,38 @@ namespace Tweeter.DAL
             return false;
             
         }
+
+        public void AddTweet(Tweet a_tweet)
+        {
+            Context.Tweets.Add(a_tweet);
+            Context.SaveChanges();
+        }
+
+        public void AddTweet(string username, string tweet_message)
+        {
+            Twit found_twit = Context.TweeterUsers.FirstOrDefault(u => u.BaseUser.UserName == username);
+            if (found_twit != null)
+            {
+                Tweet new_tweet = new Tweet
+                {
+                    Message = tweet_message,
+                    CreatedAt = DateTime.Now,
+                    Author = found_twit
+                };
+                Context.Tweets.Add(new_tweet);
+                Context.SaveChanges();
+            }
+        }
+
+        public Tweet RemoveTweet(int tweet_id)
+        {
+            Tweet found_tweet = Context.Tweets.FirstOrDefault(t => t.TweetId == tweet_id);
+            if (found_tweet != null)
+            {
+                Context.Tweets.Remove(found_tweet);
+                Context.SaveChanges();
+            }
+            return found_tweet;
+        }
     }
 }

--- a/Tweeter/DAL/TweeterRepository.cs
+++ b/Tweeter/DAL/TweeterRepository.cs
@@ -79,5 +79,10 @@ namespace Tweeter.DAL
             }
             return found_tweet;
         }
+
+        public List<Tweet> GetTweets()
+        {
+            return Context.Tweets.ToList();
+        }
     }
 }

--- a/Tweeter/Models/TweeterViewModels.cs
+++ b/Tweeter/Models/TweeterViewModels.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Web;
+
+namespace Tweeter.Models
+{
+    public class TweeterViewModels
+    {
+        public class TweetViewModel
+        {
+            [Required]
+            [MinLength(2)]
+            public string Message { get; set; }
+
+            public string ImageURL { get; set; }
+
+        }
+    }
+}

--- a/Tweeter/Scripts/app.js
+++ b/Tweeter/Scripts/app.js
@@ -1,5 +1,5 @@
 ﻿$("#register-username").keyup(function () {
-
+    //$("form").submit(true);
     $("#username-ans").removeClass("glyphicon-ok");
     $("#username-ans").removeClass("glyphicon-remove");
     $.ajax({
@@ -8,14 +8,18 @@
     }).success(function (response) {
         console.log(response.exists);
         if (!response.exists) {
-            $("#username-ans").addClass("glyphicon-ok");
-        } else {
+            $("#submit").attr("disabled", "disabled");
             $("#username-ans").addClass("glyphicon-remove");
+            
+        } else {
+            $("#submit").removeAttr("disabled");
+            $("#username-ans").addClass("glyphicon-ok");
         }
     }).fail(function (error) {
         console.log(error);
     });
 });
+
 
 
 /*

--- a/Tweeter/Views/Account/Register.cshtml
+++ b/Tweeter/Views/Account/Register.cshtml
@@ -34,7 +34,7 @@
     </div>
     <div class="form-group">
         <div class="col-md-offset-2 col-md-10">
-            <input type="submit" class="btn btn-default" value="Register" />
+            <input type="submit" id="submit" class="btn btn-default" value="Register" />
         </div>
     </div>
 }


### PR DESCRIPTION
This PR contains:

- `AddTweet`, `RemoveTweet` and `GetTweets` repo methods
- `TweetViewModel` to ease submitting Tweets via POST
- `TweetController` -> Web API controller using the `AddTweet`, `RemoveTweet` and `GetTweets` repo methods.